### PR TITLE
STAGE-588 Update widget's boilerplate repository

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,6 +139,10 @@ module.exports = function(grunt) {
                         dest: 'dist/dist/templates'
                     },
                     {
+                        src: 'security/admin_token',
+                        dest: 'dist/resources/admin_token'
+                    },
+                    {
                         expand: true,
                         cwd: 'conf',
                         src: '**',

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To do so you need to install postgress on your machine
 create a database called `stage`
 create a user called `cloudify` with password `cloudify` and grant it access to the `stage` db
 start that db
-If its not on localhost or you have different configuration (different user name, different db) you will have to chagne the configuration db.url option.
+If its not on localhost or you have different configuration (different user name, different db) you will have to change the configuration db.url option.
 
 Should you decide to run with a local DB, you will have to run the migration process to create stage tables in the new database:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Custom Widget Development Environment (CWDE)
+# Widget Development Environment (WDE) Boilerplate
 
-Custom Widget Development Environment, or CWDE in short, allows a user to create his own, custom widgets for Cloudify Stage utilizing the powerful Cloudify Api.
+Custom Widget Development Environment, or WDE in short, allows a user to create his own, custom widgets for Cloudify Stage utilizing the powerful Cloudify Api.
 There are hundreds of options and components available for customizing your Cloudify Stage experience. Learn more by checking the [Cloudify Docs](http://docs.getcloudify.org/dev/manager_webui/custom-widgets/#widget-file-structure).
 
-An example widget (`Sample Widget`) has been included with CWDE installation. You can use it as a template for developing our own, more complex widgets.
+An example widget (`Sample Widget`) has been included with WDE installation. You can use it as a template for developing our own, more complex widgets.
 #### Installation
 
 1. Clone the current repository to your computer:
@@ -22,7 +22,7 @@ cd Cloudify-UI-Widget-boilerplate
 npm install
 ```
 
-4. Adjust configuration files to point to your Cloudify instance (you need to have one running in order to use CWDE).
+4. Adjust configuration files to point to your Cloudify instance (you need to have one running in order to use WDE).
 ```
 in /conf/app.json change "influx.ip" if you want to use graphs from an influx server (By default on the manager machine, just make sure you open port 8086)
 in /conf/manager.json change "ip" to point to the manager you are using
@@ -50,7 +50,7 @@ You should have a new directory */dist* added to the root folder.
 Should you need to change configuration in the future please remember to edit the *manager.json* file in the */conf* directory (not *dist/conf/manager.json*).
 After editing any of the configuration files you must re-run `grunt build` in order to refresh */dist* directory.
 
-This step concludes CWDE installation.
+This step concludes WDE installation.
 
 #### Running the Server
 
@@ -78,7 +78,7 @@ npm run db-migrate
 
 ###### Starting the server
 
-In order to run the CWDE you will need to start three separate processes in parallel (separate terminal sessions):
+In order to run the WDE you will need to start three separate processes in parallel (separate terminal sessions):
 
 ```
 cd dist/backend/
@@ -99,14 +99,14 @@ grunt widgetsCopy
 
 > Note: The last two functions may be amalgamated into a single process in the future.
 
-This concludes CWDE start-up. You can now access your CWDE UI by navigating to http://localhost:8088/.
+This concludes WDE start-up. You can now access your WDE UI by navigating to http://localhost:8088/.
 All of your custom widgets will be available there immediately after page refresh.
 
 
 ##### Exporting widgets
 
 Once you have developed your first few widgets you may want to share them. To do so you will have to zip them, and upload to your Cloudify instance via `Add widget` feature.
-To zip all the widgets in your CWDE run the following command:
+To zip all the widgets in your WDE run the following command:
 
 ```
 grunt widgetsZip

--- a/README.md
+++ b/README.md
@@ -1,108 +1,122 @@
-# Widget Writing env boilerplate
+# Custom Widget Development Environment (CWDE)
 
-### Build the project
+Custom Widget Development Environment, or CWDE in short, allows a user to create his own, custom widgets for Cloudify Stage utilizing the powerful Cloudify Api.
+There are hundreds of options and components available for customizing your Cloudify Stage experience. Learn more by checking the [Cloudify Docs](http://docs.getcloudify.org/dev/manager_webui/custom-widgets/#widget-file-structure).
 
-#### First run
+An example widget (`Sample Widget`) has been included with CWDE installation. You can use it as a template for developing our own, more complex widgets.
+#### Installation
+
+1. Clone the current repository to your computer:
+```
+git clone https://github.com/cloudify-cosmo/Cloudify-UI-Widget-boilerplate.git
+cd Cloudify-UI-Widget-boilerplate
+```
+
+2. Make sure you have the appropriate cloudify-stage version configured in package.json:
+```
+"cloudify-stage-dist": "http://cloudify-release-eu.s3.amazonaws.com/cloudify/17.11.22/build/cloudify-stage-17.11.22-community.tgz"
+```
+
+3. Download the necessary npm libraries:
 ```
 npm install
 ```
 
-#### Change the configuration files to point to the manager you want to access
+4. Adjust configuration files to point to your Cloudify instance (you need to have one running in order to use CWDE).
+```
 in /conf/app.json change "influx.ip" if you want to use graphs from an influx server (By default on the manager machine, just make sure you open port 8086)
 in /conf/manager.json change "ip" to point to the manager you are using
+```
 
-#### To set up the dev env run
+5. Download authentication token from your Cloudify instance. You can either:
+* Manually put the *admin_token* file, if you already have it, into /security/ directory, or
+* Use the provided automated script to pull the appropriate *admin_token* directly from your Cloudify manager. To do so, however, you will need to have direct ssh access to the Cloudify host.
+Please see the /security/download_token.sh script and fill in the required fields before running it:
+```
+export KEY_PATH=./security/cloudify.key
+export MANAGER_IP="10.239.0.180"
+```
+> `KEY_PATH` is where your private SSH key resides. This is the same file that was used during Cloudify manager instance creation. \
+> `MANAGER_IP` the same IP address as in #step 4
+
+then run the ```download_token.sh``` script (skip if you already have the *admin_token* file).
+
+5. Build the project
 ```
 grunt build
 ```
+> Note: This will setup the stage server and will copy your widgets to the widget library of the server.
+You should have a new directory */dist* added to the root folder.
+Should you need to change configuration in the future please remember to edit the *manager.json* file in the */conf* directory (not *dist/conf/manager.json*).
+After editing any of the configuration files you must re-run `grunt build` in order to refresh */dist* directory.
 
-This will setup the stage server and will copy your widgets to the widget library of the server.
+This step concludes CWDE installation.
 
-#### Start the server by running:
+#### Running the Server
 
-```
-npm start
-```
+###### DB configuration
+Before the server can be started you need to prepare a valid DB connection for the "Proxy" to use. There are two possible options to achieve this:
+* First one is to use the db on the manager machine.
+To do so you will have to change the configuration in *conf/app.json* to point to the correct address:
+`"url": "postgres://cloudify:cloudify@localhost:5432/stage"`
 
-### For widget development
-
-For development purposes setup the server as described above
-also run both grunt tasks in different command windows:
-
-```
-grunt widgets
-```
-
-This will compile the widgets (from widget src folder) and create widget.js from it.
-
-
-```
-grunt widgetsCopy
-```
-
-This will start a listener on the widgets library and will copy any changes you make on the fly to the server
-You will have to click refresh on the browser for it to take effect.
-
-
-** Note: im trying to combine those but it took too much effort so i left it like this.
-
-
-In order to deploy this to prod environment,  need to run the first 2 steps (copy stage server files and run 'grunt build').
-then copy the dist lib (zip it and unzip in server)
-
-#### DB configuration
-You have a few options
-First one is to use the db on the manager machine.
-To do so you will have to change the configuration file to point to it. conf/app.json , change "db.url" to postgres://cloudify:cloudify@your-manager-ip:5432/stage
-
-Second option is to create your own db (usually on localhost).
-You will have to install postgress
-create a db called stage
-create a user called cloudify with password cloudify and grant it access to stage db
+* Second option is to create your own db (usually on localhost).
+To do so you need to install postgress on your machine
+create a database called `stage`
+create a user called `cloudify` with password `cloudify` and grant it access to the `stage` db
 start that db
 If its not on localhost or you have different configuration (different user name, different db) you will have to chagne the configuration db.url option.
 
-Then you will have to run the migration process to create stage tables on that db.
+Should you decide to run with a local DB, you will have to run the migration process to create stage tables in the new database:
 
 ```
 cd dist/backend
 npm run db-migrate
 ```
 
-** This will have to happen after you copied the configuration file if you changed it so it will know which DB to connect to.
+> Note: Please remember to re-build the */dist* folder after each change in the configuraion. Otherwise the "Proxy" will not notice the changes (#Installation->step 5)
 
+###### Starting the server
 
-#### Start the server by running
+In order to run the CWDE you will need to start three separate processes in parallel (separate terminal sessions):
 
 ```
-export NODE_TLS_REJECT_UNAUTHORIZED=0
-cd dist/backend
-node server.js
+cd dist/backend/
+npm start
+
+cd ../../
+grunt widgets
+grunt widgetsCopy
 ```
 
-** first line is to use ssl for the manager communications without using the certificate file. You can also change the manager communication to use http on port 80 in manager.json config file.
+> Note: You may need to run `export NODE_TLS_REJECT_UNAUTHORIZED=0` before `npm start` to enable ssl for the manager communications without using the certificate file.
+> Alternatively, you can change the manager.json to use `http` and port `80` instead.
 
-## Zip the widgets
+* `npm start` - runs the "backend" or "proxy" server mediating between the Cloudify manager and your local UI.
+* `grunt widgets` - compiles the widgets (from widget src folder) and create widget.js from it.
+* `grunt widgetsCopy` - starts a listener on the widgets library and will copy any changes you make on the fly to the server
+                        You will have to click refresh on the browser for it to take effect.
 
-You can zip the widgets so you can install them on an existing stage environment.
-Each widget is zipped in a single zip file (we currently dont support multiple widgets per zip).
+> Note: The last two functions may be amalgamated into a single process in the future.
 
-To zip all the widgets in your env run
+This concludes CWDE start-up. You can now access your CWDE UI by navigating to http://localhost:8088/.
+All of your custom widgets will be available there immediately after page refresh.
+
+
+##### Exporting widgets
+
+Once you have developed your first few widgets you may want to share them. To do so you will have to zip them, and upload to your Cloudify instance via `Add widget` feature.
+To zip all the widgets in your CWDE run the following command:
 
 ```
 grunt widgetsZip
 ```
 
 This will create a zip file for each widget in the 'output' folder
+> Note: Each widget will be zipped to a separate zip file (Cloudify currently does not support multiple widgets per zip).
 
-You can take those zip files and install them (via edit-mode->add widget->install) in an existing stage envorinment.
+You can take the result zip files and install them (via edit-mode->add widget->install) in an existing Cloudify Stage environment.
 
-
-### other grunt tasks
-If you add another widget library and want it to take effect (copy to dist) either run "grunt build", or simply run - "grunt registerWidget"
-
-If you change the configuration files after you already ran grunt build once, no need to run it again. Simply change the configuration and run
-
-```
-grunt copy:resources
-```
+##### Other useful commands
+* If you add another widget library and want it to take effect (copy to dist) either run `grunt build`, or simply run `grunt registerWidget`
+* If you change the configuration files after you already ran grunt build once, no need to run it again. Simply change the configuration and run `grunt copy:resources`

--- a/conf/manager.json
+++ b/conf/manager.json
@@ -3,6 +3,5 @@
   "apiVersion": "v3.1",
   "serverVersion": "4.2.0",
   "protocol" : "https",
-  "port": "53333",
-  "restSecurityFile" : "../conf/rest-security.conf"
+  "port": "53333"
 }

--- a/conf/rest-security.conf
+++ b/conf/rest-security.conf
@@ -1,4 +1,0 @@
-{
-  "admin_username": "admin",
-  "admin_password": "admin"
-}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "",
   "homepage": "https://cloudify-cosmo/Cloudify-UI-Widget-boilerplate#readme",
   "dependencies": {
-    "cloudify-stage-dist": "http://cloudify-release-eu.s3.amazonaws.com/cloudify/4.2.0/.dev1-build/cloudify-stage-4.2.0-.dev1.tgz"
+    "cloudify-stage-dist": "http://cloudify-release-eu.s3.amazonaws.com/cloudify/17.11.22/build/cloudify-stage-17.11.22-community.tgz"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",

--- a/security/download_token.sh
+++ b/security/download_token.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+#path to machine's private key
+export KEY_PATH=./cloudify.key
+export MANAGER_IP=""
+
+echo "Manager ip is: $MANAGER_IP"
+rsync -Pav -e "ssh -o StrictHostKeyChecking=no -i $KEY_PATH" centos@$MANAGER_IP:/opt/cloudify-stage/resources/ ./

--- a/widgets/sampleWidget/src/widget.js
+++ b/widgets/sampleWidget/src/widget.js
@@ -8,8 +8,7 @@ Stage.defineWidget({
     initialHeight: 8,
     color: 'green',
     isReact: true,
-    permission: 'widget-user',
-
+    permission: Stage.GenericConfig.CUSTOM_WIDGET_PERMISSIONS.CUSTOM_ALL,
 
     render: function() {
         return (


### PR DESCRIPTION
- Removed obsolete 'rest-security' references
- Removed 'rest-security.conf'
- Changed sampleWidget permissions to CUSTOM_ALL (could not view it as admin with old permissions)
- Added admin_token to 'grunt build', as a mandatory pre-requisite
- Updated package.json to use the latest Community Stage (instead of premium dev build)
- Overhauled the readme.md to be more explanatory and in line with most recent changes both to manager and stage
- Added download_token.sh script to enable automated auth_token download from Cloudify manager host